### PR TITLE
add support for Zicbo* extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.4] - 2023-02-22
+- Add support for Zicbo* extension
+
 ## [1.25.3] - 2023-01-24
 - use "make -k" in riscof_model.py template to ensure all test cases run, even after a failure. Fixes #73.
 

--- a/riscof/framework/test.py
+++ b/riscof/framework/test.py
@@ -335,6 +335,10 @@ def generate_test_pool(ispec, pspec, workdir, dbfile = None):
                 macros.append("FLEN=64")
             elif re.match(r"^[^(Z,z)]+F.*$",isa):
                 macros.append("FLEN=32")
+            if 'cbozero' in file:
+                macros.append("RVMODEL_CBZ_BLOCKSIZE="+str(pspec['zicbo_cache_block_sz']['zicboz_sz']))
+            elif 'cbo' in file:
+                macros.append("RVMODEL_CMO_BLOCKSIZE="+str(pspec['zicbo_cache_block_sz']['zicbom_sz']))
             test_pool.append(
                 (file, db[file]['commit_id'], macros,isa,cov_labels))
     logger.info("Selecting Tests.")


### PR DESCRIPTION
this PR will add support for Zicbo* extension. It also add BLOCKSZ macro which will be used by tests for cbo.zero. The cache block size can be configured by riscv-config with cmo support(https://github.com/riscv-software-src/riscv-config/pull/79)
