### PR TITLE
Fix isa generation logic to account for same test with different XLENs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.24.0] - 2022-0514
+## [1.24.1] - 2022-07-19
+- Account for the same test to be included with both XLEN variants in the isa generation.
+- Add markdown report for coverage statistics.
+
+## [1.24.0] - 2022-05-14
 - rename the "master" branch of riscv-arch-test to "main"  
 
 ## [1.23.4] - 2022-02-24

--- a/riscof/cli.py
+++ b/riscof/cli.py
@@ -432,6 +432,10 @@ def coverage(ctx,config,work_dir,suite,env,no_browser,cgf_file):
     with open(reportfile, "w") as report:
         report.write(output)
 
+    with open(reportfile.replace("html","md"),"w") as report_md:
+        template = Template(constants.coverage_report_md)
+        report_md.write(template.render(report_objects))
+
     shutil.copyfile(constants.css,
                     os.path.join(work_dir, "style.css"))
 

--- a/riscof/constants.py
+++ b/riscof/constants.py
@@ -40,4 +40,12 @@ target_run=1
 pluginpath={1}
 '''
 
+coverage_report_md = '''
+|Covergroup|Coverage|
+|:--------:|:------:|
+{% for result in results %}
+|{{result.name}}|{{result.coverage}} ({{result.percentage}}%)|
+{%endfor%}
+'''
+
 

--- a/riscof/constants.py
+++ b/riscof/constants.py
@@ -43,7 +43,8 @@ pluginpath={1}
 coverage_report_md = '''
 |Covergroup|Coverage|
 |:--------:|:------:|
-{% for result in results %}|{{result.name}}|{{result.coverage}} ({{result.percentage}}%)|{%endfor%}
+{% for result in results %}|{{result.name}}|{{result.coverage}} ({{result.percentage}}%)|
+{%endfor%}
 '''
 
 

--- a/riscof/constants.py
+++ b/riscof/constants.py
@@ -43,9 +43,7 @@ pluginpath={1}
 coverage_report_md = '''
 |Covergroup|Coverage|
 |:--------:|:------:|
-{% for result in results %}
-|{{result.name}}|{{result.coverage}} ({{result.percentage}}%)|
-{%endfor%}
+{% for result in results %}|{{result.name}}|{{result.coverage}} ({{result.percentage}}%)|{%endfor%}
 '''
 
 

--- a/riscof/framework/main.py
+++ b/riscof/framework/main.py
@@ -126,10 +126,15 @@ def run_coverage(base, dut_isa_spec, dut_platform_spec, work_dir, cgf_file=None)
                             'test_size': [str(entry) for entry in find_elf_size(elf)],
                             'test_groups': str(set(test_list[entry[0]]['coverage_labels']))
                             })
+    flen = 0
+    if 'F' in ispec['ISA']:
+        flen = 32
+    elif 'D' in ispec['ISA']:
+        flen = 64
     if 64 in ispec['supported_xlen']:
-        results = isac.merge_coverage(cov_files, expand_cgf(cgf_file,64), True, 64)
+        results = isac.merge_coverage(cov_files, expand_cgf(cgf_file,64,flen), True)
     elif 32 in ispec['supported_xlen']:
-        results = isac.merge_coverage(cov_files, expand_cgf(cgf_file,32), True, 32)
+        results = isac.merge_coverage(cov_files, expand_cgf(cgf_file,32,flen), True)
 
 
 #    results_yaml = yaml.load(results)
@@ -165,7 +170,7 @@ def run(dut, base, dut_isa_spec, dut_platform_spec, work_dir, cntr_args):
 
         :param dut_platform_spec: The absolute path to the checked yaml containing
             the DUT platform specification.
-            
+
         :param cntr_args: dbfile, testfile, no_ref_run, no_dut_run
 
         :type dut_platform_spec: str
@@ -184,7 +189,7 @@ def run(dut, base, dut_isa_spec, dut_platform_spec, work_dir, cntr_args):
     #Loading Specs
     ispec = utils.load_yaml(dut_isa_spec)
     pspec = utils.load_yaml(dut_platform_spec)
-    
+
     if cntr_args[2]:
         logger.info("Running Build for DUT")
         dut.build(dut_isa_spec, dut_platform_spec)

--- a/riscof/framework/test.py
+++ b/riscof/framework/test.py
@@ -298,19 +298,15 @@ def prod_isa(dut_isa, test_isa):
     isa = set([])
     last_prefix = ''
     atleast_1 = False
-
+    match = re.findall("(?P<prefix>RV(64|128|32)(I|E))",dut_isa)
+    prefix = match[0][0]
     for entry in test_isa:
         match = re.findall("(?P<prefix>RV(64|128|32)(I|E))",entry)
-        prefix = match[0][0]
         exts = isa_set(re.sub("RV(64|128|32)(I|E)","",entry))
         overlap = dut_exts & exts
-        if overlap == exts:
+        if overlap == exts and match[0][0] == prefix:
             atleast_1 = True
             isa = isa | overlap
-            if last_prefix:
-                if last_prefix != prefix:
-                    raise TestSelectError("Incompatiple prefix for valid ISA strings in test.")
-            last_prefix = prefix
     if not atleast_1:
         raise TestSelectError("Test Selected without the relevant extensions being available on DUT.")
     return prefix+canonicalise(isa)


### PR DESCRIPTION
- Account for the same test to be included with both XLEN variants in the isa generation.
- Add markdown report for coverage statistics.