### PR TITLE
Fix riscv_config dependency version to 2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2022-07-27
+- Fix `riscv_config` dependency version to 2.10.1
+
 ## [1.24.1] - 2022-07-19
 - Account for the same test to be included with both XLEN variants in the isa generation.
 - Add markdown report for coverage statistics.

--- a/riscof/__init__.py
+++ b/riscof/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '1.24.1'
+__version__ = '1.24.2'

--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -2,5 +2,5 @@ GitPython==3.1.17
 click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
-riscv-config>=2.10.1
+riscv-config==2.10.1
 riscv_isac>=0.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.1
+current_version = 1.24.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup_requirements = [ ]
 test_requirements = [ ]
 
 setup(name="riscof",
-      version='1.24.1',
+      version='1.24.2',
       description="RISC-V Architectural Test Framework",
       long_description=readme + '\n\n',
       classifiers=[


### PR DESCRIPTION
Currently, `riscof` execution errors out due to a breaking change in `riscv_config`: riscv-software-src/riscv-config#90.

This is meant to be a temporary fix until all the instances in the code base which use the `warl_interpreter` from `riscv_config.warl` are changed to use the `warl_class`.