### PR TITLE
Fix riscv config version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.3] - 2022-08-29
+- fix typeo in doc for command related to cloning arch-suites
+- bump riscv-config version to be 2.17.0
+
 ## [1.24.2] - 2022-07-27
 - Fix `riscv_config` dependency version to 2.10.1
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -469,7 +469,7 @@ models. To create a copy of the latest tests from the riscv-arch-test repository
 
 .. code-block:: console
     
-    $ riscof --verbose info arch-tests --clone
+    $ riscof --verbose info arch-test --clone
 
 This will create a riscv-arch-test in the current working directory.
    

--- a/riscof/__init__.py
+++ b/riscof/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '1.24.2'
+__version__ = '1.24.3'

--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -2,5 +2,5 @@ GitPython==3.1.17
 click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
-riscv-config==2.10.1
+riscv-config==2.17.0
 riscv_isac>=0.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.2
+current_version = 1.24.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup_requirements = [ ]
 test_requirements = [ ]
 
 setup(name="riscof",
-      version='1.24.2',
+      version='1.24.3',
       description="RISC-V Architectural Test Framework",
       long_description=readme + '\n\n',
       classifiers=[


### PR DESCRIPTION
- fix typo in doc for command related to cloning arch-suites
- bump riscv-config version to be 2.17.0
