### PR TITLE
Fix for the issue https://github.com/riscv-software-src/riscof/issues/62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-##[1.25.1] - 2022-09-09
+## [1.25.1] - 2022-09-09
 - Modified the code to fix the issue #62, which changed the condition to allow flen=64 for D extension tests.
 
 ## [1.25.0] - 2022-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+##[1.25.1] - 2022-09-09
+- Modified the code to fix the issue #62, which changed the condition to allow flen=64 for D extension tests.
+
 ## [1.25.0] - 2022-09-07
 - migrated to using riscv-config version 3.2.0+
 - modified functions to use the new warl_class from riscv-config-3.2.0+

--- a/riscof/__init__.py
+++ b/riscof/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '1.25.0'
+__version__ = '1.25.1'

--- a/riscof/framework/main.py
+++ b/riscof/framework/main.py
@@ -129,7 +129,7 @@ def run_coverage(base, dut_isa_spec, dut_platform_spec, work_dir, cgf_file=None)
     flen = 0
     if 'F' in ispec['ISA']:
         flen = 32
-    elif 'D' in ispec['ISA']:
+    if 'D' in ispec['ISA']:
         flen = 64
     if 64 in ispec['supported_xlen']:
         results = isac.merge_coverage(cov_files, expand_cgf(cgf_file,64,flen), True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.0
+current_version = 1.25.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup_requirements = [ ]
 test_requirements = [ ]
 
 setup(name="riscof",
-      version='1.25.0',
+      version='1.25.1',
       description="RISC-V Architectural Test Framework",
       long_description=readme + '\n\n',
       classifiers=[


### PR DESCRIPTION
Added both F and D from the ISA independently, as the extension D always comes along with F. Hence the order of F followed by D. This also fix this [issue](https://github.com/riscv-software-src/riscof/issues/62).