### PR TITLE
riscof_model.py fixes: don't use __init__ return value; use make -k. Fixes #71, #73.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.3] - 2023-01-24
+- use "make -k" in riscof_model.py template to ensure all test cases run, even after a failure. Fixes #73.
+
 ## [1.25.2] - 2022-10-08
 - updating paths for docker image and plugins to point to new location
 

--- a/riscof/Templates/setup/model/riscof_model.py
+++ b/riscof/Templates/setup/model/riscof_model.py
@@ -117,7 +117,7 @@ class dutname(pluginTemplate):
 
       # set the make command that will be used. The num_jobs parameter was set in the __init__
       # function earlier
-      make.makeCommand = 'make -j' + self.num_jobs
+      make.makeCommand = 'make -k -j' + self.num_jobs
 
       # we will iterate over each entry in the testList. Each entry node will be refered to by the
       # variable testname.

--- a/riscof/Templates/setup/model/riscof_model.py
+++ b/riscof/Templates/setup/model/riscof_model.py
@@ -22,7 +22,7 @@ class dutname(pluginTemplate):
     __version__ = "XXX"
 
     def __init__(self, *args, **kwargs):
-        sclass = super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         config = kwargs.get('config')
 
@@ -58,9 +58,6 @@ class dutname(pluginTemplate):
             self.target_run = False
         else:
             self.target_run = True
-
-        # Return the parameters set above back to RISCOF for further processing.
-        return sclass
 
     def initialise(self, suite, work_dir, archtest_env):
 

--- a/riscof/__init__.py
+++ b/riscof/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '1.25.2'
+__version__ = '1.25.3'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.2
+current_version = 1.25.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup_requirements = [ ]
 test_requirements = [ ]
 
 setup(name="riscof",
-      version='1.25.2',
+      version='1.25.3',
       description="RISC-V Architectural Test Framework",
       long_description=readme + '\n\n',
       classifiers=[


### PR DESCRIPTION
This would ordinarily be too nit-picky even in a code review, and I'd leave it alone (and would not expect anyone to merge it.) However, this code is used as a template and will proliferate. It's already showed up in a few RISCOF integrations into third-party RISC-V cores.