### PR TITLE
Fix version to 3.7 in actions. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6.15'
+          python-version: '3.7'
   
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Python `3.6.x` is no longer supported by the action. 