### PR TITLE
Ensure a non-zero return code is set if expected when --no-browser is provided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.4] - 2023-04-25
+- Ensure correct riscof return code when `--no-browser` is used. Fixes #87.
+
 ## [1.25.3] - 2023-01-24
 - use "make -k" in riscof_model.py template to ensure all test cases run, even after a failure. Fixes #73.
 

--- a/riscof/cli.py
+++ b/riscof/cli.py
@@ -352,6 +352,8 @@ def run(ctx,config,work_dir,suite,env,no_browser,dbfile,testfile,no_ref_run,no_d
             raise SystemExit(exitcode)
         except:
             raise SystemExit(exitcode)
+    elif exitcode:
+        raise SystemExit(exitcode)
 
 
 


### PR DESCRIPTION
This change just ensures that the return code is set if non-zero.