### PR TITLE
Remove unused pip import in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ versioned header while the `WIP-DEV` is left empty
 - Ensure correct riscof return code when `--no-browser` is used. Fixes #87.
 - Updating CONTRIBUTING.rst to capture the new git strategy adopted to follow a monthly release
 - Fix typo in installation.rst
+- Remove unused pip import in setup.py
 
 ## [1.25.3] - 2023-01-24
 - use "make -k" in riscof_model.py template to ensure all test cases run, even after a failure. Fixes #73.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import codecs
-import pip
 from setuptools import setup, find_packages
 
 # Base directory of package


### PR DESCRIPTION
This import doesn't seem to be used, and it breaks when building this package in an environment without `pip`.