### PR TITLE
Support for Translator and Macros

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -53,6 +53,7 @@ Optional arguments from the cli:
   ``./riscof_work``
 - no-browser: when used, RISCOF skips automatically opening the html report in the default web
   browser.
+- header file: macro file to include for the coverage of the test suite. This can be added using the ``-h`` flag.
 
 The coverage command simply passes the cgf files to the reference plugin's runTests function. The
 Reference plugin is responsible to generating a yaml based coverage report for each test using ``riscv-isac``. 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,8 +35,7 @@ version = get_version()
 release = version
 
 def setup(app):
-    app.add_stylesheet("custom.css")
-    app.add_css_file("_static/custom.css")
+    app.add_css_file("custom.css")
 
 # -- General configuration ---------------------------------------------------
 
@@ -88,6 +87,8 @@ exclude_patterns = ['_build']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+#Mention the reference files
+bibtex_bibfiles = ['refs.bib']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/coverage.rst
+++ b/docs/source/coverage.rst
@@ -40,13 +40,39 @@ used to check for coverage. A sample ``config.ini`` is shown below::
    [cSail]                                                                                             
    pluginpath=/home/neel/temp/riscof-plugins/sail_cSim
 
+To check the options available for the ``coverage``, help text can be accessed by executing ``riscof coverage --help``
+
+.. code-block:: shell-session
+
+   Usage: riscof coverage [OPTIONS]
+
+      Run the tests on DUT and reference and compare signatures
+
+   Options:
+   --suite PATH            Path to the custom Suite Directory.  [required]
+   --env PATH              Path to the env directory for the suite.  [required]
+   --config PATH           The Path to the config file. [Default=./config.ini]
+   --work-dir PATH         Path to the work directory. [Default =
+                           ./riscof_work]
+   --no-browser            Do not open the browser for showing the test report.
+   -c, --cgf-file PATH     Coverage Group File(s). Multiple allowed.
+                           [required]
+   -h, --header-file PATH  YAML macro file to include
+   --help                  Show this message and exit.
+
 To run coverage
 
 .. code-block:: shell-session
 
    $ riscof --verbose debug coverage --suite /path/to/suite --env /path/to/suite
 
-The log of the above command is shown below:
+Or, to run coverage including the macros file:
+
+.. code-block:: shell-session
+
+   $ riscof --verbose debug coverage --suite /path/to/suite --env /path/to/suite -h /path/to/header_file
+
+The log of the above commands is shown below:
 
 .. code-block:: shell-session
 
@@ -71,6 +97,8 @@ The log of the above command is shown below:
      INFO | [--riscof.framework.test--]: Selecting Tests.
      INFO | [--riscof.framework.main--]: Running Tests on Reference.
      INFO | [--riscof.framework.main--]: Merging Coverage reports
+     INFO | [--riscof.framework.main--]: Translating
+     INFO | [--riscof.framework.main--]: Preprocessing
      INFO | [--root--]: Test report generated at /home/neel/temp/riscof_work/coverage.html.
      INFO | [--root--]: Openning test report in web-browser
 

--- a/riscof/Templates/setup/sail_cSim/riscof_sail_cSim.py
+++ b/riscof/Templates/setup/sail_cSim/riscof_sail_cSim.py
@@ -79,7 +79,7 @@ class sail_cSim(pluginTemplate):
             raise SystemExit(1)
 
 
-    def runTests(self, testList, cgf_file=None):
+    def runTests(self, testList, cgf_file=None, header_file= None):
         if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
             os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
         make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
@@ -107,13 +107,17 @@ class sail_cSim(pluginTemplate):
             for label in testentry['coverage_labels']:
                 cov_str+=' -l '+label
 
+            cgf_mac = ' '
+            for macro in testentry['mac']:
+                cgf_mac+=' -cm '+macro
+
             if cgf_file is not None:
                 coverage_cmd = 'riscv_isac --verbose info coverage -d \
                         -t {0}.log --parser-name c_sail -o coverage.rpt  \
                         --sig-label begin_signature  end_signature \
                         --test-label rvtest_code_begin rvtest_code_end \
-                        -e ref.elf -c {1} -x{2} {3};'.format(\
-                        test_name, ' -c '.join(cgf_file), self.xlen, cov_str)
+                        -e ref.elf -c {1} -x{2} {3} -h {4};'.format(\
+                        test_name, ' -c '.join(cgf_file), self.xlen, cov_str, header_file)
             else:
                 coverage_cmd = ''
 

--- a/riscof/Templates/setup/sail_cSim/riscof_sail_cSim.py
+++ b/riscof/Templates/setup/sail_cSim/riscof_sail_cSim.py
@@ -108,16 +108,20 @@ class sail_cSim(pluginTemplate):
                 cov_str+=' -l '+label
 
             cgf_mac = ' '
-            for macro in testentry['mac']:
-                cgf_mac+=' -cm '+macro
+            header_file_flag = ' '
+            if header_file is not None:
+                header_file_flag = f' -h {header_file} '
+                cgf_mac += ' -cm common '
+                for macro in testentry['mac']:
+                    cgf_mac+=' -cm '+macro
 
             if cgf_file is not None:
                 coverage_cmd = 'riscv_isac --verbose info coverage -d \
                         -t {0}.log --parser-name c_sail -o coverage.rpt  \
                         --sig-label begin_signature  end_signature \
                         --test-label rvtest_code_begin rvtest_code_end \
-                        -e ref.elf -c {1} -x{2} {3} -h {4};'.format(\
-                        test_name, ' -c '.join(cgf_file), self.xlen, cov_str, header_file)
+                        -e ref.elf -c {1} -x{2} {3} {4} {5};'.format(\
+                        test_name, ' -c '.join(cgf_file), self.xlen, cov_str, header_file_flag, cgf_mac)
             else:
                 coverage_cmd = ''
 

--- a/riscof/cli.py
+++ b/riscof/cli.py
@@ -153,7 +153,6 @@ class CustomOption(click.Option):
 def cli(ctx,verbose):
     logger.level(verbose)
     logger.info('****** RISCOF: RISC-V Architectural Test Framework {0} *******'.format(__version__ ))
-    logger.info("Hello from RICSOF -- Hammad One")
     logger.info('using riscv_isac version : ' + str(riscv_isac.__version__))
     logger.info('using riscv_config version : ' + str(riscv_config.__version__))
     ctx.obj = Context()

--- a/riscof/cli.py
+++ b/riscof/cli.py
@@ -153,6 +153,7 @@ class CustomOption(click.Option):
 def cli(ctx,verbose):
     logger.level(verbose)
     logger.info('****** RISCOF: RISC-V Architectural Test Framework {0} *******'.format(__version__ ))
+    logger.info("Hello from RICSOF -- Hammad One")
     logger.info('using riscv_isac version : ' + str(riscv_isac.__version__))
     logger.info('using riscv_config version : ' + str(riscv_config.__version__))
     ctx.obj = Context()
@@ -376,8 +377,13 @@ def run(ctx,config,work_dir,suite,env,no_browser,dbfile,testfile,no_ref_run,no_d
         type=click.Path(resolve_path=True,readable=True,exists=True),
         help="Coverage Group File(s). Multiple allowed.",required=True
     )
+@click.option(
+        '--header-file','-h',metavar='PATH',
+        type=click.Path(resolve_path=True,readable=True,exists=True),
+        help="YAML macro file to include"
+    )
 @click.pass_context
-def coverage(ctx,config,work_dir,suite,env,no_browser,cgf_file):
+def coverage(ctx,config,work_dir,suite,env,no_browser,cgf_file,header_file):
     setup_directories(work_dir)
     ctx.obj.mkdir = False
     ctx.obj.config, ctx.obj.config_dir = read_config(config)
@@ -399,7 +405,7 @@ def coverage(ctx,config,work_dir,suite,env,no_browser,cgf_file):
     with open(platform_file, "r") as platfile:
         pspecs = platfile.read()
     report, for_html, test_stats, coverpoints = framework.run_coverage(base, isa_file, platform_file,
-            work_dir, cgf_file)
+            work_dir, cgf_file, header_file)
     report_file = open(work_dir+'/suite_coverage.rpt','w')
     utils.dump_yaml(report, report_file)
     report_file.close()

--- a/riscof/dbgen.py
+++ b/riscof/dbgen.py
@@ -114,13 +114,16 @@ def createdict(file):
 
                     check = []
                     define = []
+                    cgf_macro = []
                     for cond in conditions:
                         cond = cond.strip()
                         if (cond.startswith('check')):
                             check.append(cond)
                         elif (cond.startswith('def')):
                             define.append(cond)
-                    part_dict[part_number] = {'check': check, 'define': define,'coverage_labels':labels}
+                        elif (cond.startswith('mac')):
+                            cgf_macro.append(cond)
+                    part_dict[part_number] = {'check': check, 'define': define, 'mac':cgf_macro, 'coverage_labels':labels}
                 else:
                     logger.warning("{}:{}: Incorrect Case String ({})".format(file, lno, part_number))
                     logger.warning("Skipping file {}. This test will not be included in the\

--- a/riscof/framework/main.py
+++ b/riscof/framework/main.py
@@ -136,9 +136,10 @@ def run_coverage(base, dut_isa_spec, dut_platform_spec, work_dir, cgf_file=None,
     if 'D' in ispec['ISA']:
         flen = 64
     if 64 in ispec['supported_xlen']:
-        results = isac.merge_coverage(cov_files, preprocessing(Translate_cgf(expand_cgf(cgf_file,64,flen), header_file, cgf_macros)), True)
+        results = isac.merge_coverage(cov_files, preprocessing(Translate_cgf(expand_cgf(cgf_file,64,flen)), header_file, cgf_macros), True)
     elif 32 in ispec['supported_xlen']:
-        results = isac.merge_coverage(cov_files, preprocessing(Translate_cgf(expand_cgf(cgf_file,32,flen), header_file, cgf_macros)), True)
+        print(cov_files)
+        results = isac.merge_coverage(cov_files, preprocessing(Translate_cgf(expand_cgf(cgf_file,32,flen)), header_file, cgf_macros), True)
 
 
 #    results_yaml = yaml.load(results)

--- a/riscof/framework/main.py
+++ b/riscof/framework/main.py
@@ -8,6 +8,8 @@ import riscof.framework.test as test
 import riscof.utils as utils
 import riscof.constants as constants
 import riscv_isac.coverage as isac
+from riscv_isac.isac import preprocessing
+from riscv_isac.plugins.translator_cgf import Translate_cgf
 from riscv_isac.utils import load_cgf
 from riscv_isac.cgf_normalize import expand_cgf
 import ruamel
@@ -76,7 +78,7 @@ def find_elf_size(elf):
         # size = e_shoff + e_ehsize + (e_phnum * e_phentsize) + (e_shnum * e_shentsize)
         return (sum([segment['p_memsz'] for segment in elffile.iter_segments()]),code_size,data_size,sign_size)
 
-def run_coverage(base, dut_isa_spec, dut_platform_spec, work_dir, cgf_file=None):
+def run_coverage(base, dut_isa_spec, dut_platform_spec, work_dir, cgf_file=None, header_file=None):
     '''
         Entry point for the framework module. This function initializes and sets up the required
         variables for the tests to run.
@@ -111,12 +113,13 @@ def run_coverage(base, dut_isa_spec, dut_platform_spec, work_dir, cgf_file=None)
 
     test_list, test_pool = test.generate_test_pool(ispec, pspec, work_dir)
     logger.info("Running Tests on Reference.")
-    base.runTests(test_list, cgf_file)
+    base.runTests(test_list, cgf_file, header_file)
 
 
     logger.info("Merging Coverage reports")
     cov_files = []
     test_stats = []
+    cgf_macros = ()
     for entry in test_pool:
         work_dir = test_list[entry[0]]['work_dir']
         test_name = work_dir.rsplit('/',1)[1][:-2]
@@ -126,15 +129,16 @@ def run_coverage(base, dut_isa_spec, dut_platform_spec, work_dir, cgf_file=None)
                             'test_size': [str(entry) for entry in find_elf_size(elf)],
                             'test_groups': str(set(test_list[entry[0]]['coverage_labels']))
                             })
+        cgf_macros += tuple(entry[5])
     flen = 0
     if 'F' in ispec['ISA']:
         flen = 32
     if 'D' in ispec['ISA']:
         flen = 64
     if 64 in ispec['supported_xlen']:
-        results = isac.merge_coverage(cov_files, expand_cgf(cgf_file,64,flen), True)
+        results = isac.merge_coverage(cov_files, preprocessing(Translate_cgf(expand_cgf(cgf_file,64,flen), header_file, cgf_macros)), True)
     elif 32 in ispec['supported_xlen']:
-        results = isac.merge_coverage(cov_files, expand_cgf(cgf_file,32,flen), True)
+        results = isac.merge_coverage(cov_files, preprocessing(Translate_cgf(expand_cgf(cgf_file,32,flen), header_file, cgf_macros)), True)
 
 
 #    results_yaml = yaml.load(results)

--- a/riscof/framework/test.py
+++ b/riscof/framework/test.py
@@ -305,6 +305,7 @@ def generate_test_pool(ispec, pspec, workdir, dbfile = None):
     for file in db:
         macros = []
         cov_labels = []
+        cgf_macros = []
         for part in db[file]['parts']:
             include = True
             part_dict = db[file]['parts'][part]
@@ -318,6 +319,8 @@ def generate_test_pool(ispec, pspec, workdir, dbfile = None):
                     temp = eval_macro(macro, spec)
                     if (temp[0]):
                         macros.extend(temp[1])
+                for cgf_macro in part_dict['mac']:
+                    cgf_macros.extend([cgf_macro.split(" ")[1]])
         if not macros == []:
             try:
                 isa = prod_isa(ispec['ISA'],db[file]['isa'])
@@ -336,7 +339,7 @@ def generate_test_pool(ispec, pspec, workdir, dbfile = None):
             elif re.match(r"^[^(Z,z)]+F.*$",isa):
                 macros.append("FLEN=32")
             test_pool.append(
-                (file, db[file]['commit_id'], macros,isa,cov_labels))
+                (file, db[file]['commit_id'], macros,isa,cov_labels,cgf_macros))
     logger.info("Selecting Tests.")
     for entry in test_pool:
         # logger.info("Test file:" + entry[0])
@@ -350,6 +353,7 @@ def generate_test_pool(ispec, pspec, workdir, dbfile = None):
         temp['work_dir']=work_dir
         temp['macros']=entry[2]
         temp['isa']=entry[3]
+        temp['mac']=entry[5]
         temp['coverage_labels'] = entry[4]
         if constants.suite in entry[0]:
             temp['test_path'] = entry[0]


### PR DESCRIPTION
This pull request is linked to the feature enhancement PR#[80](https://github.com/riscv-software-src/riscv-isac/pull/80) created in RISC-V ISAC related to **Support for coverage of Privileged Architecture**

In this pull request, I have added:
1. The Translator feature support that has been created in collaboration with @allenjbaum.
2. The Macros feature that can be used to improve the coverpoint writing process. Hence, the user may use the riscof command for the coverage to use his/her macros in the test label like:
```c-objective
    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True; mac self",PMP_TOR_priority_r)

```
And add the header_file for the macros in the CLI for riscof as:
```
riscof coverage --config=config.ini --cgf-file=dataset.cgf --cgf-file=testing_coverpoint.cgf --suite=Testing_dir --env=env -h /home/header_file.yaml
```

`Note: The documentation will be added within a day or two for the translator and the features as well for macros.`

@neelgala @pawks Please assign someone the reviewer for this PR as well.

@UmerShahidengr