### PR TITLE
Remove hardcoded GitPython version

### DIFF
--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -1,4 +1,4 @@
-GitPython==3.1.17
+GitPython>=3.1.17
 click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1


### PR DESCRIPTION
RISCOF works when using the latest release of GitPython (3.1.43), so there is no reason to require an older version. There have been many updates (especially security updates) released since the version that is currently pinned. There is also a warning message regarding the currently required version of GitPython (3.1.17) being a yanked version when installing RISCOF.

This PR keeps the minimum version the same while allowing newer versions to be used to resolve the above issues.