### PR TITLE
Updated requirements.txt for riscv-isac

### DIFF
--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -3,4 +3,4 @@ click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
 riscv-config>=3.2.0
-git+https://github.com/riscv-software-src/riscv-isac@dev
+riscv-isac=='dev'

--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -3,4 +3,4 @@ click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
 riscv-config>=3.2.0
-riscv-isac=='dev'
+riscv_isac

--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -3,4 +3,4 @@ click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
 riscv-config>=3.2.0
-riscv_isac @ git+https://github.com/riscv-software-src/riscof@dev
+riscv-isac @ git+https://github.com/riscv-software-src/riscv-isac@dev

--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -3,4 +3,4 @@ click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
 riscv-config>=3.2.0
-riscv_isac>=0.7.2
+git+https://github.com/riscv-software-src/riscv-isac@dev

--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -3,4 +3,4 @@ click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
 riscv-config>=3.2.0
-riscv_isac=="dev"
+riscv_isac @ git+https://github.com/riscv-software-src/riscof@dev

--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -3,4 +3,4 @@ click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
 riscv-config>=3.2.0
-riscv_isac
+riscv_isac=="dev"

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ setup(name="riscof",
           ]
       },
       install_requires=read_requires(),
+      dependency_links=[
+          'git+https://github.com/riscv-software-src/riscv-isac@dev'
+      ],
       python_requires=">=3.6.0",
       entry_points={
           "console_scripts": ["riscof=riscof.cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,6 @@ setup(name="riscof",
           ]
       },
       install_requires=read_requires(),
-      dependency_links=[
-          'git+https://github.com/riscv-software-src/riscv-isac@dev'
-      ],
       python_requires=">=3.6.0",
       entry_points={
           "console_scripts": ["riscof=riscof.cli:cli"],


### PR DESCRIPTION
A temporary workaround for #122 (not recommended as the prerequisite is that git is needed to be installed).