### PR TITLE
Updated riscv_isac version. #122

### DIFF
--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -3,4 +3,4 @@ click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
 riscv-config>=3.2.0
-riscv_isac @ git+https://github.com/riscv-software-src/riscv-isac@777d2b4
+riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac

--- a/riscof/requirements.txt
+++ b/riscof/requirements.txt
@@ -3,4 +3,4 @@ click>=7.1.2
 Jinja2>=2.10.1
 pytz>=2019.1
 riscv-config>=3.2.0
-riscv_isac>=0.7.2
+riscv_isac @ git+https://github.com/riscv-software-src/riscv-isac@777d2b4


### PR DESCRIPTION
Fixes bug of `preprocessing` function not being found. 

```sh
from riscv_isac.isac import preprocessing
```