### PR TITLE
update to sail simulator build instructions and plugin, necessary for newer version of sail

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -273,20 +273,15 @@ These are often used as reference models in RISCOF.
 
        $ sudo apt-get install opam  build-essential libgmp-dev z3 pkg-config zlib1g-dev
        $ opam init -y --disable-sandboxing
-       $ opam switch create ocaml-base-compiler.4.06.1
+       $ opam switch create ocaml-base-compiler
        $ opam install sail -y
        $ eval $(opam config env)
        $ git clone https://github.com/riscv/sail-riscv.git
        $ cd sail-riscv
-       $ make
-       $ ARCH=RV32 make
-       $ ARCH=RV64 make
-       $ ln -s sail-riscv/c_emulator/riscv_sim_RV64 /usr/bin/riscv_sim_RV64
-       $ ln -s sail-riscv/c_emulator/riscv_sim_RV32 /usr/bin/riscv_sim_RV32
+       $ ./build_simulators.sh
 
-    This will create a C simulator in ``c_emulator/riscv_sim_RV64`` and
-    ``c_emulator/riscv_sim_RV32``. You will not need to add these paths in your ``$PATH`` or an
-    alias to it to execute them from command line.
+    This will create a C simulator executables ``riscv_sim_rv32d`` and ``riscv_sim_rv64d``
+    in the folder ``build/c_emulator/``. Add the folder to the ``$PATH`` environmantal variable.
 
     **Alternative 2: Using Docker**
 
@@ -421,8 +416,8 @@ The generate template ``config.ini`` will look something like this by default::
   [sail_cSim]
   pluginpath=/path/to/riscof/sail_cSim
 
-If the SAIL binaries (i.e. ``riscv_sim_RV32``) are not in your $PATH you may want to add the following to the last line of the
-above config::
+If the SAIL binaries (i.e. ``riscv_sim_rv32d``/``riscv_sim_rv64d``) are not in your $PATH
+you may want to add the following to the last line of the above config::
 
   PATH=<path_to_my_Sail_binaries>
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -801,7 +801,7 @@ is used as a reference for this example.
 .. code-block:: Makefile
     :linenos:    
 
-    TARGET_SIM   ?= riscv_sim_RV32 -V
+    TARGET_SIM   ?= riscv_sim_rv32d -V
     TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
     ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
         $(error Target simulator executable '$(TARGET_SIM)` not found)
@@ -882,7 +882,7 @@ the final makefile looks like this:
 .. code-block:: Makefile
     :linenos:
 
-    TARGET_SIM   ?= riscv_sim_RV32 -V
+    TARGET_SIM   ?= riscv_sim_rv32d -V
     TARGET_FLAGS =
     
     RISCV_PREFIX   ?= riscv32-unknown-elf-

--- a/riscof/Templates/setup/sail_cSim/riscof_sail_cSim.py
+++ b/riscof/Templates/setup/sail_cSim/riscof_sail_cSim.py
@@ -17,7 +17,7 @@ logger = logging.getLogger()
 
 class sail_cSim(pluginTemplate):
     __model__ = "sail_c_simulator"
-    __version__ = "0.5.0"
+    __version__ = "0.5.1"
 
     def __init__(self, *args, **kwargs):
         sclass = super().__init__(*args, **kwargs)
@@ -28,8 +28,8 @@ class sail_cSim(pluginTemplate):
             raise SystemExit(1)
         self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
         self.pluginpath = os.path.abspath(config['pluginpath'])
-        self.sail_exe = { '32' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV32"),
-                '64' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV64")}
+        self.sail_exe = { '32' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_rv32d"),
+                          '64' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_rv64d")}
         self.isa_spec = os.path.abspath(config['ispec']) if 'ispec' in config else ''
         self.platform_spec = os.path.abspath(config['pspec']) if 'ispec' in config else ''
         self.make = config['make'] if 'make' in config else 'make'


### PR DESCRIPTION
The instructions for building sail did not work properly.
I updated the instructions and the names of the executables created by the newer version of sail.